### PR TITLE
specify api-version in plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: MultiWorldMoney
 main: com.wasteofplastic.multiworldmoney.MultiWorldMoney
 version: ${version}
+api-version: 1.13
 depend: [Vault]
 softdepend: [Multiverse-Core, Essentials]
 commands:


### PR DESCRIPTION
Set api-version to 1.13 which removes the warning about legacy addon when loading the plugin.